### PR TITLE
🧹 Remove unused get_waterfall_service import

### DIFF
--- a/verify_institutional_grade.py
+++ b/verify_institutional_grade.py
@@ -13,7 +13,6 @@ sys.path.append(os.path.join(os.getcwd(), 'backend'))
 from ai_firm.agent_manager import AgentManager
 from services.knowledge_base import get_knowledge_base
 from services.trade_validator import TradeValidator
-from services.market_data_service_waterfall import get_waterfall_service
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("Verification")


### PR DESCRIPTION
🎯 **What:** Removed the unused import `get_waterfall_service` from `verify_institutional_grade.py`.
💡 **Why:** Cleans up the namespace and improves maintainability by removing dead code.
✅ **Verification:** Tested the file for syntax errors using `python3 -m py_compile` to ensure no syntax issues were introduced.
✨ **Result:** Cleaner code without affecting any runtime behavior.

---
*PR created automatically by Jules for task [4923529816152226506](https://jules.google.com/task/4923529816152226506) started by @TechAD101*