### PR TITLE
🧹 [code health improvement] Remove unused json and datetime imports from run_rl_backtest.py

### DIFF
--- a/run_rl_backtest.py
+++ b/run_rl_backtest.py
@@ -1,8 +1,6 @@
 
 import sys
 import os
-import json
-from datetime import datetime
 
 # Add backend to path
 sys.path.append(os.path.abspath('backend'))


### PR DESCRIPTION
🎯 What: Removed the unused `import json` and `from datetime import datetime` statements from `run_rl_backtest.py`.
💡 Why: Having unused imports pollutes the namespace and can slightly increase load times or confuse developers. Removing them improves the file's maintainability.
✅ Verification: Code syntax was compiled to verify the correctness of the removal, ensuring no broken syntax was introduced. The functionality of the script is identical because the removed imports were completely unused.
✨ Result: Cleaner namespace and more readable code.

---
*PR created automatically by Jules for task [6979746223182178809](https://jules.google.com/task/6979746223182178809) started by @TechAD101*