### PR TITLE
fix: conditionally apply pysqlite3 patch for ChromaDB

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,12 +28,14 @@ except Exception:
 
 # --- RENDER/CHROMA DB PATCH ---
 # Fix for old SQLite versions on Render/Linux
-try:
-    __import__('pysqlite3')
-    import sys
-    sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
-except ImportError:
-    pass
+import sqlite3
+if sqlite3.sqlite_version_info < (3, 35, 0):
+    try:
+        __import__('pysqlite3')
+        import sys
+        sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+    except ImportError:
+        pass
 # ------------------------------
 
 load_dotenv()


### PR DESCRIPTION
Update `backend/main.py` to only swap the `sqlite3` module with `pysqlite3` if the system's `sqlite3` version is older than `3.35.0`. This makes the workaround targeted and safer, avoiding unnecessary module replacements on systems with a sufficient version of `sqlite3` for ChromaDB.

---
*PR created automatically by Jules for task [5455043582409305082](https://jules.google.com/task/5455043582409305082) started by @TechAD101*