### PR TITLE
🔒 Fix overly permissive CORS configuration

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -186,7 +186,14 @@ except Exception as e:
 
 
 app = Flask(__name__)
-CORS(app, origins=['*'])
+
+# Secure CORS configuration
+cors_origins_env = os.getenv('CORS_ORIGINS')
+if cors_origins_env:
+    allowed_origins = [origin.strip() for origin in cors_origins_env.split(',')]
+else:
+    allowed_origins = ['http://localhost:5173', 'http://localhost:3000']
+CORS(app, origins=allowed_origins)
 
 # Register Institutional Blueprints
 from routes.data_ingest import data_ingest_bp


### PR DESCRIPTION
🎯 **What:** Replaced wildcard origin `'*'` in Flask-CORS with a strictly configurable whitelist.

⚠️ **Risk:** A wildcard CORS policy allows any external domain to make cross-origin requests to the API, exposing sensitive data to Cross-Site Request Forgery (CSRF) and data theft if left unfixed.

🛡️ **Solution:** Configured Flask-CORS to read allowed origins from the `CORS_ORIGINS` environment variable, defaulting securely to localhost during development.

---
*PR created automatically by Jules for task [8873193791329008990](https://jules.google.com/task/8873193791329008990) started by @TechAD101*