### PR TITLE
🧪 [test] add fallback unit tests for data whisperer

### DIFF
--- a/tests/test_data_whisperer_ml_mocked.py
+++ b/tests/test_data_whisperer_ml_mocked.py
@@ -93,5 +93,63 @@ class TestDataWhispererML(unittest.TestCase):
         self.assertEqual(result['sentiment_source'], 'heuristic_fallback')
         self.assertEqual(result['sentiment_confidence'], 0.5)
 
+class TestDataWhispererFallback(unittest.TestCase):
+    def setUp(self):
+        # Reset mocks
+        market_data_mock.get_latest_price.reset_mock()
+        market_data_mock.get_latest_price.return_value = 150.0
+
+        # Save original and mock cb
+        import ai_agents.data_whisperer as dw
+        self.original_cb = dw.cb
+        dw.cb = MagicMock()
+
+    def tearDown(self):
+        import ai_agents.data_whisperer as dw
+        dw.cb = self.original_cb
+
+    def test_circuit_breaker_open_fallback(self):
+        import ai_agents.data_whisperer as dw
+        dw.cb.allow_request.return_value = False
+
+        result = analyze_data("AAPL")
+
+        self.assertGreaterEqual(result['price'], 10000)
+        self.assertLessEqual(result['price'], 60000)
+        dw.cb.allow_request.assert_called_once_with("AAPL")
+
+    def test_circuit_breaker_exception_allows_request(self):
+        import ai_agents.data_whisperer as dw
+        dw.cb.allow_request.side_effect = Exception("Redis connection error")
+
+        result = analyze_data("AAPL")
+
+        self.assertEqual(result['price'], 150.0)
+        dw.cb.allow_request.assert_called_once_with("AAPL")
+        market_data_mock.get_latest_price.assert_called_once_with("AAPL")
+
+    def test_get_latest_price_exception_fallback(self):
+        import ai_agents.data_whisperer as dw
+        dw.cb.allow_request.return_value = True
+        market_data_mock.get_latest_price.side_effect = Exception("API timeout")
+
+        result = analyze_data("AAPL")
+
+        self.assertGreaterEqual(result['price'], 10000)
+        self.assertLessEqual(result['price'], 60000)
+        dw.cb.record_failure.assert_called_once_with("AAPL")
+
+    def test_get_latest_price_returns_none_fallback(self):
+        import ai_agents.data_whisperer as dw
+        dw.cb.allow_request.return_value = True
+        market_data_mock.get_latest_price.return_value = None
+
+        result = analyze_data("AAPL")
+
+        self.assertGreaterEqual(result['price'], 10000)
+        self.assertLessEqual(result['price'], 60000)
+        dw.cb.record_failure.assert_called_once_with("AAPL")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added unit test coverage for the fallback behavior of the circuit breaker in `backend/ai_agents/data_whisperer.py`.
📊 **Coverage:** Covered scenarios where `allow_request` returns `False` or raises an exception, as well as where `get_latest_price` raises an exception or returns `None`.
✨ **Result:** The test suite now explicitly covers the fallback logic to random values correctly.

---
*PR created automatically by Jules for task [5808480762816933570](https://jules.google.com/task/5808480762816933570) started by @TechAD101*