### PR TITLE
🧪 Add tests for testConnection in frontend api.js

### DIFF
--- a/frontend/src/api/api.test.js
+++ b/frontend/src/api/api.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { testConnection, BASE_URL } from './api';
+
+describe('api.js - testConnection', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should return connected: true and data on successful fetch', async () => {
+    const mockData = { status: 'ok', uptime: 123 };
+    global.fetch.mockResolvedValueOnce({
+      json: vi.fn().mockResolvedValueOnce(mockData)
+    });
+
+    const result = await testConnection();
+
+    expect(global.fetch).toHaveBeenCalledWith(`${BASE_URL}/health`);
+    expect(result).toEqual({ connected: true, ...mockData });
+  });
+
+  it('should return connected: false and error message on failed fetch', async () => {
+    const mockError = new Error('Network error');
+    global.fetch.mockRejectedValueOnce(mockError);
+
+    const result = await testConnection();
+
+    expect(global.fetch).toHaveBeenCalledWith(`${BASE_URL}/health`);
+    expect(result).toEqual({ connected: false, error: 'Network error' });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: The `testConnection` function in `frontend/src/api/api.js` was completely untested, leading to potential unseen regressions. This commit creates an `api.test.js` file utilizing vitest to implement unit testing with global fetch mock interceptors.

📊 **Coverage:** What scenarios are now tested:
- Successful connection (the happy path resolving a healthy payload)
- Connection failure (simulating a rejected fetch promise yielding an error string)

✨ **Result:** The improvement in test coverage allows us to securely lean on our api wrapping methods moving forward without worrying about silent breakage.

---
*PR created automatically by Jules for task [8260370451452159201](https://jules.google.com/task/8260370451452159201) started by @TechAD101*