### PR TITLE
🧪 Add test for oracle wisdom endpoint fallback

### DIFF
--- a/tests/test_oracle_wisdom.py
+++ b/tests/test_oracle_wisdom.py
@@ -3,9 +3,13 @@ import sys
 import pytest
 from unittest.mock import patch, MagicMock
 
+
 @pytest.fixture(autouse=True)
 def setup_teardown_mocks():
     missing_modules = ['numpy', 'flask', 'requests', 'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext.declarative', 'alpaca', 'chromadb', 'chromadb.config', 'google', 'google.generativeai', 'redis', 'pydantic', 'openai', 'anthropic', 'httpx', 'flask_cors']
+
+    # Snapshot sys.modules keys before
+    old_modules = set(sys.modules.keys())
 
     with patch.dict(sys.modules, {mod: MagicMock() for mod in missing_modules}):
         class MockApp:
@@ -31,6 +35,12 @@ def setup_teardown_mocks():
             def teardown_appcontext(self, f):
                 return f
 
+            def app_context(self):
+                class DummyContext:
+                    def __enter__(self): pass
+                    def __exit__(self, *args): pass
+                return DummyContext()
+
             def errorhandler(self, exception):
                 def decorator(f):
                     return f
@@ -54,44 +64,49 @@ def setup_teardown_mocks():
 
         if os.path.join(os.path.dirname(__file__), '..', 'backend') in sys.path:
             sys.path.remove(os.path.join(os.path.dirname(__file__), '..', 'backend'))
-        if 'main' in sys.modules:
-            sys.modules.pop('main')
+
+        # Pop everything that was added
+        new_modules = set(sys.modules.keys()) - old_modules
+        for mod in new_modules:
+            sys.modules.pop(mod, None)
 
 
 def test_oracle_wisdom_fallback():
     import main
+    app = main.app
 
     # Store old values
     old_ready = main.AI_FIRM_READY
     old_oracle = getattr(main, 'oracle_service', None)
 
     try:
+        with app.app_context():
         # Test fallback when AI_FIRM_READY is False
-        main.AI_FIRM_READY = False
-        res = main.get_oracle_wisdom()
+            main.AI_FIRM_READY = False
+            res = main.get_oracle_wisdom()
 
-        # In main.py, it returns a tuple: jsonify(...), 200
-        assert isinstance(res, tuple)
-        res_data, status_code = res
-        assert status_code == 200
-        assert hasattr(res_data, 'json')
-        assert 'oracle_wisdom' in res_data.json
-        assert 'metadata' in res_data.json['oracle_wisdom']
-        assert res_data.json['oracle_wisdom']['metadata']['status'] == 'offline'
-        assert res_data.json['oracle_wisdom']['metadata']['source'] == 'Akasha Node (Offline)'
+            # In main.py, it returns a tuple: jsonify(...), 200
+            assert isinstance(res, tuple)
+            res_data, status_code = res
+            assert status_code == 200
+            assert hasattr(res_data, 'json')
+            assert 'oracle_wisdom' in res_data.json
+            assert 'metadata' in res_data.json['oracle_wisdom']
+            assert res_data.json['oracle_wisdom']['metadata']['status'] == 'offline'
+            assert res_data.json['oracle_wisdom']['metadata']['source'] == 'Akasha Node (Offline)'
 
-        # Test fallback when oracle_service is None
-        main.AI_FIRM_READY = True
-        main.oracle_service = None
-        res = main.get_oracle_wisdom()
+            # Test fallback when oracle_service is None
+            main.AI_FIRM_READY = True
+            main.oracle_service = None
+            res = main.get_oracle_wisdom()
 
-        assert isinstance(res, tuple)
-        res_data, status_code = res
-        assert status_code == 200
-        assert hasattr(res_data, 'json')
-        assert 'oracle_wisdom' in res_data.json
-        assert 'metadata' in res_data.json['oracle_wisdom']
-        assert res_data.json['oracle_wisdom']['metadata']['status'] == 'offline'
+            assert isinstance(res, tuple)
+            res_data, status_code = res
+            assert status_code == 200
+            assert hasattr(res_data, 'json')
+            assert 'oracle_wisdom' in res_data.json
+            assert 'metadata' in res_data.json['oracle_wisdom']
+            assert res_data.json['oracle_wisdom']['metadata']['status'] == 'offline'
 
     finally:
         # Restore old values

--- a/tests/test_oracle_wisdom.py
+++ b/tests/test_oracle_wisdom.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+@pytest.fixture(autouse=True)
+def setup_teardown_mocks():
+    missing_modules = ['numpy', 'flask', 'requests', 'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext.declarative', 'alpaca', 'chromadb', 'chromadb.config', 'google', 'google.generativeai', 'redis', 'pydantic', 'openai', 'anthropic', 'httpx', 'flask_cors']
+
+    with patch.dict(sys.modules, {mod: MagicMock() for mod in missing_modules}):
+        class MockApp:
+            def __init__(self):
+                self.config = {}
+                self.route_map = {}
+
+            def route(self, path, methods=None):
+                def decorator(f):
+                    self.route_map[path] = f
+                    return f
+                return decorator
+
+            def register_blueprint(self, bp, url_prefix=None):
+                pass
+
+            def before_request(self, f):
+                return f
+
+            def after_request(self, f):
+                return f
+
+            def teardown_appcontext(self, f):
+                return f
+
+            def errorhandler(self, exception):
+                def decorator(f):
+                    return f
+                return decorator
+
+        mock_app = MockApp()
+
+        def mock_jsonify(data):
+            m = MagicMock()
+            m.json = data
+            return m
+
+        sys.modules['flask'].Flask = MagicMock(return_value=mock_app)
+        sys.modules['flask'].request = MagicMock()
+        sys.modules['flask'].jsonify = mock_jsonify
+        sys.modules['flask'].Blueprint = MagicMock()
+
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+
+        yield
+
+        if os.path.join(os.path.dirname(__file__), '..', 'backend') in sys.path:
+            sys.path.remove(os.path.join(os.path.dirname(__file__), '..', 'backend'))
+        if 'main' in sys.modules:
+            sys.modules.pop('main')
+
+
+def test_oracle_wisdom_fallback():
+    import main
+
+    # Store old values
+    old_ready = main.AI_FIRM_READY
+    old_oracle = main.oracle_service
+
+    try:
+        # Test fallback when AI_FIRM_READY is False
+        main.AI_FIRM_READY = False
+        res = main.get_oracle_wisdom()
+
+        # In main.py, it returns a tuple: jsonify(...), 200
+        assert isinstance(res, tuple)
+        res_data, status_code = res
+        assert status_code == 200
+        assert hasattr(res_data, 'json')
+        assert 'oracle_wisdom' in res_data.json
+        assert 'metadata' in res_data.json['oracle_wisdom']
+        assert res_data.json['oracle_wisdom']['metadata']['status'] == 'offline'
+        assert res_data.json['oracle_wisdom']['metadata']['source'] == 'Akasha Node (Offline)'
+
+        # Test fallback when oracle_service is None
+        main.AI_FIRM_READY = True
+        main.oracle_service = None
+        res = main.get_oracle_wisdom()
+
+        assert isinstance(res, tuple)
+        res_data, status_code = res
+        assert status_code == 200
+        assert hasattr(res_data, 'json')
+        assert 'oracle_wisdom' in res_data.json
+        assert 'metadata' in res_data.json['oracle_wisdom']
+        assert res_data.json['oracle_wisdom']['metadata']['status'] == 'offline'
+
+    finally:
+        # Restore old values
+        main.AI_FIRM_READY = old_ready
+        main.oracle_service = old_oracle

--- a/tests/test_oracle_wisdom.py
+++ b/tests/test_oracle_wisdom.py
@@ -63,7 +63,7 @@ def test_oracle_wisdom_fallback():
 
     # Store old values
     old_ready = main.AI_FIRM_READY
-    old_oracle = main.oracle_service
+    old_oracle = getattr(main, 'oracle_service', None)
 
     try:
         # Test fallback when AI_FIRM_READY is False


### PR DESCRIPTION
🎯 **What:** Added tests to verify the fallback JSON response of the `/api/oracle/wisdom` endpoint when `AI_FIRM_READY` is false or `oracle_service` is unavailable. This test fills a coverage gap in the main routing module.
📊 **Coverage:** Successfully covered both the `AI_FIRM_READY = False` and `oracle_service = None` conditions in the Oracle wisdom fallback route.
✨ **Result:** Enhanced the API endpoint reliability with specific assertions confirming that the offline metadata is returned correctly. The test successfully executes inside a fully isolated `sys.modules` patch context to prevent test-suite pollution.

---
*PR created automatically by Jules for task [8472612469369497426](https://jules.google.com/task/8472612469369497426) started by @TechAD101*