### PR TITLE
🧹 [code health] Remove unused Config import in service_registry.py

### DIFF
--- a/backend/service_registry.py
+++ b/backend/service_registry.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Dict, Any, Optional
-from config import Config
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
🎯 What: Removed the unused `Config` import from `backend/service_registry.py`.
💡 Why: The `Config` class was imported but never utilized within the `ServiceRegistry` module, leading to unnecessary dependencies and potential confusion. Removing it improves codebase maintainability and readability.
✅ Verification: Ran `python3 -m py_compile backend/service_registry.py` to ensure syntax validity. Existing `pytest` runs fail due to unrelated environment issues (missing `sqlalchemy`/`flask`), but the removal of an unused import is perfectly safe.
✨ Result: Cleaner imports, reduced noise, and improved code health without altering behavior.

---
*PR created automatically by Jules for task [15737288120701030430](https://jules.google.com/task/15737288120701030430) started by @TechAD101*