### PR TITLE
🧹 Remove unused typing and config imports from service registry

### DIFF
--- a/backend/service_registry.py
+++ b/backend/service_registry.py
@@ -1,6 +1,4 @@
 import logging
-from typing import Dict, Any, Optional
-from config import Config
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
🎯 What: Removed the unused `typing` and `config` imports from `backend/service_registry.py`.
💡 Why: Improves code health by reducing unused clutter and potential namespace confusion.
✅ Verification: Ran syntax checks and existing test suites. Code review passed.
✨ Result: Cleaner, more maintainable code file with no functional changes.

---
*PR created automatically by Jules for task [7487907942868714795](https://jules.google.com/task/7487907942868714795) started by @TechAD101*