### PR TITLE
Fix conditional SQLite patch for ChromaDB

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,12 +28,14 @@ except Exception:
 
 # --- RENDER/CHROMA DB PATCH ---
 # Fix for old SQLite versions on Render/Linux
-try:
-    __import__('pysqlite3')
-    import sys
-    sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
-except ImportError:
-    pass
+import sqlite3
+if sqlite3.sqlite_version_info < (3, 35, 0):
+    try:
+        __import__('pysqlite3')
+        import sys
+        sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+    except ImportError:
+        pass
 # ------------------------------
 
 load_dotenv()


### PR DESCRIPTION
The existing patch for ChromaDB unconditionally overrode the built-in `sqlite3` module with `pysqlite3` if the latter was available. This change wraps the overriding logic in a version check (`sqlite3.sqlite_version_info < (3, 35, 0)`), ensuring it's only applied when absolutely necessary on older Linux/Render environments, thus avoiding potential downgrade or interference with functional, modern SQLite installations.

---
*PR created automatically by Jules for task [3272591352600572381](https://jules.google.com/task/3272591352600572381) started by @TechAD101*