### PR TITLE
🧪 Add unit tests for auth_service hash_password

### DIFF
--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import hashlib
+import pytest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+
+# Use patch.dict to safely mock dependencies without polluting the global sys.modules for other tests
+with patch.dict('sys.modules', {
+    'sqlalchemy': MagicMock(),
+    'sqlalchemy.orm': MagicMock(),
+    'sqlalchemy.ext.declarative': MagicMock()
+}):
+    from auth_service import hash_password
+
+def test_hash_password_basic():
+    """Test hashing a normal string."""
+    password = "my_secure_password"
+    expected = hashlib.sha256(password.encode()).hexdigest()
+    assert hash_password(password) == expected
+
+def test_hash_password_empty():
+    """Test hashing an empty string."""
+    password = ""
+    expected = hashlib.sha256(password.encode()).hexdigest()
+    assert hash_password(password) == expected
+
+def test_hash_password_special_chars():
+    """Test hashing a string with special characters."""
+    password = "!@#$%^&*()_+~`|}{[]:;?><,./-="
+    expected = hashlib.sha256(password.encode()).hexdigest()
+    assert hash_password(password) == expected
+
+def test_hash_password_unicode():
+    """Test hashing a string with Unicode characters (emojis)."""
+    password = "hello🌍world🔥"
+    expected = hashlib.sha256(password.encode()).hexdigest()
+    assert hash_password(password) == expected
+
+def test_hash_password_deterministic():
+    """Test that hashing the same string twice produces the same result."""
+    password = "deterministic_test"
+    assert hash_password(password) == hash_password(password)
+
+def test_hash_password_different_inputs():
+    """Test that different inputs produce different hashes."""
+    assert hash_password("password123") != hash_password("password124")


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the `hash_password` function in `backend/auth_service.py` to address an existing testing gap. 

📊 **Coverage:**
The new test suite provides complete test coverage for `hash_password` and checks:
- Normal strings
- Empty strings
- Special characters
- Unicode characters (emojis)
- Determinism (same input yields the same hash)
- Uniqueness (different inputs yield different hashes)

✨ **Result:**
Improved test coverage and confidence in the core authentication utilities without introducing regressions. The test uses a safe `patch.dict` method to mock unneeded global modules like `sqlalchemy` so it executes perfectly in restricted CI environments.

---
*PR created automatically by Jules for task [6655188910953293947](https://jules.google.com/task/6655188910953293947) started by @TechAD101*