### PR TITLE
Fix: Map market_provider reference to market_data

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -141,18 +141,23 @@ try:
     market_data = MarketDataService(market_config)
     market_provider = market_data  # Fix: Create the market_provider reference
     registry.register_service('market_data', market_data)
+    registry.register_service('market_provider', market_provider)
     MARKET_SERVICE_READY = True
     logger.info("✅ MarketDataService initialized successfully")
 except Exception as e:
     logger.error(f"❌ MarketDataService initialization failed: {e}")
     # Fallback to prevent crashes
     class DummyMarketProvider:
+        def __init__(self): self.active_provider = 'Fallback'
         def get_price(self, symbol): return {'price': 0, 'error': 'Market data unavailable'}
         def get_fundamentals(self, symbol): return {}
         def get_verification_stats(self): return {}
         def get_price_verified(self, symbol): return {'verified': False, 'price': 0}
         def get_recent_audit_logs(self, limit): return []
     market_provider = DummyMarketProvider()
+    market_data = market_provider
+    registry.register_service('market_data', market_data)
+    registry.register_service('market_provider', market_provider)
 
 # Initialize AI Firm
 AI_FIRM_READY = False


### PR DESCRIPTION
This pull request fixes the `market_provider` reference issue in `backend/main.py`.

It ensures that both `market_data` and `market_provider` point to the same instance (either `MarketDataService` or `DummyMarketProvider` as a fallback) and that both are explicitly registered with the `ServiceRegistry` under their respective keys. Additionally, the `DummyMarketProvider` fallback class was updated to include the `active_provider` attribute set to `'Fallback'` to satisfy potential downstream requirements.

---
*PR created automatically by Jules for task [1663621068779545017](https://jules.google.com/task/1663621068779545017) started by @TechAD101*