### PR TITLE
🧪 [testing improvement] Add test for 0-price memecoin simulation

### DIFF
--- a/backend/memecoin_service.py
+++ b/backend/memecoin_service.py
@@ -75,7 +75,7 @@ def simulate_trade(symbol: str, usd: float) -> Dict[str, Any]:
     session = get_session()
     try:
         m = session.query(Memecoin).filter_by(symbol=symbol.upper()).first()
-        if m and m.meta and m.meta.get('price'):
+        if m and m.meta and m.meta.get('price') is not None:
             price = m.meta['price']
         else:
             price = round(random.uniform(0.0001, 5.0), 6)

--- a/tests/test_memecoin.py
+++ b/tests/test_memecoin.py
@@ -43,3 +43,25 @@ def test_simulate_trade():
     res = ok.get_json()['result']
     assert res['symbol'] == 'TEST1'
     assert 'quantity' in res
+
+def test_simulate_trade_price_zero():
+    import main
+    from db import get_session
+    from models import Memecoin
+
+    # Insert Memecoin with price 0
+    session = get_session()
+    m = Memecoin(symbol='ZERO', score=0, meta={'price': 0})
+    session.add(m)
+    session.commit()
+    session.close()
+
+    client = main.app.test_client()
+
+    # Simulate with symbol ZERO
+    ok = client.post('/api/memecoin/simulate', json={'symbol': 'ZERO', 'usd': 100})
+    assert ok.status_code == 200
+    res = ok.get_json()['result']
+    assert res['symbol'] == 'ZERO'
+    assert res['price'] == 0
+    assert res['quantity'] == 0


### PR DESCRIPTION
🎯 **What:** Added a missing edge-case test to cover the `simulate_trade` memecoin API when a memecoin's recorded price in the database is exactly `0`. It was found that a price of `0` was being treated as falsy, causing a fallback to a random price generation. This bug in `memecoin_service.py` was fixed alongside the new test.

📊 **Coverage:** A new test `test_simulate_trade_price_zero` in `tests/test_memecoin.py` creates a 0-price memecoin and verifies that the simulation safely yields 0 quantity and uses a 0 price. 

✨ **Result:** A safer, more predictable paper trading simulation that correctly respects zero-price conditions without unintentionally assigning randomized fallback prices.

---
*PR created automatically by Jules for task [1799286566434078402](https://jules.google.com/task/1799286566434078402) started by @TechAD101*