### PR TITLE
🧹 [Code Health] Move ThreadPoolExecutor import to top of data_whisperer.py

### DIFF
--- a/backend/ai_agents/data_whisperer.py
+++ b/backend/ai_agents/data_whisperer.py
@@ -1,6 +1,7 @@
 # ai_agents/data_whisperer.py - Enhanced Data Analysis Agent
 
 import random
+from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, Any
 from services.market_data_service import get_latest_price
 
@@ -272,8 +273,6 @@ def _detect_market_phase(price: float) -> str:
 
 
 # --- Parallel agent execution utility ---
-from concurrent.futures import ThreadPoolExecutor
-
 def run_agents_in_parallel(agent_funcs, *args, **kwargs):
     """
     Run multiple agent functions in parallel threads for efficiency.


### PR DESCRIPTION
🎯 What: Moved ThreadPoolExecutor import from the middle of backend/ai_agents/data_whisperer.py to the top.
💡 Why: To comply with PEP 8 and standard Python conventions, improving maintainability and readability by keeping all imports at the top of the file.
✅ Verification: Verified by compiling the file via py_compile and running tests/test_data_whisperer_ml_mocked.py which passed.
✨ Result: A cleaner file conforming to standard Python conventions without changing any functionality.

---
*PR created automatically by Jules for task [13704165132945618232](https://jules.google.com/task/13704165132945618232) started by @TechAD101*