### PR TITLE
⚡ Optimize Memecoin scan_market query

### DIFF
--- a/backend/memecoin_service.py
+++ b/backend/memecoin_service.py
@@ -43,9 +43,15 @@ def scan_market(sample_symbols: List[str]) -> List[Dict[str, Any]]:
     # Persist top 3 to DB for quick access
     session = get_session()
     try:
-        for r in results[:3]:
-            # Upsert by symbol
-            m = session.query(Memecoin).filter_by(symbol=r['symbol']).first()
+        top_results = results[:3]
+        symbols = [r['symbol'] for r in top_results]
+
+        # Batch fetch existing memecoins to avoid N+1 query
+        existing_coins = session.query(Memecoin).filter(Memecoin.symbol.in_(symbols)).all()
+        existing_coin_map = {m.symbol: m for m in existing_coins}
+
+        for r in top_results:
+            m = existing_coin_map.get(r['symbol'])
             if not m:
                 m = Memecoin(symbol=r['symbol'], score=r['degen_score'], meta={'social': r['social'], 'mentions': r['mentions'], 'price': r['price'], 'momentum': r['momentum']})
                 session.add(m)


### PR DESCRIPTION
💡 **What:**
Replaced the individual DB lookups inside the `scan_market` results loop with a single batch query using an `IN` clause. 

🎯 **Why:**
The original code performed a `session.query(Memecoin).filter_by(symbol=r['symbol']).first()` inside the loop, resulting in an N+1 query problem. This scaled poorly if we decided to persist more memecoins.

📊 **Measured Improvement:**
Using a logical mocking benchmark script (since the DB environment restricts actual timing), we demonstrated a reduction from N queries to 1 query. For the default top 3 candidates, queries were reduced from 3 to 1. For a hypothetical top 100, queries reduced from 100 to 1, demonstrating an O(1) query complexity versus the original O(N) complexity.

---
*PR created automatically by Jules for task [17834652536647002910](https://jules.google.com/task/17834652536647002910) started by @TechAD101*