### PR TITLE
🧹 [Code Health] Move inline time imports to module level

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -41,6 +41,7 @@ load_dotenv()
 # Suppress ChromaDB telemetry noise
 os.environ['ANONYMIZED_TELEMETRY'] = 'False'
 
+import time
 import numpy as np
 from datetime import datetime, timedelta
 from functools import wraps
@@ -851,7 +852,6 @@ def market_price_stream():
 
                 # Sleep, but break if client disconnects (Flask will close generator)
                 try:
-                    import time
                     time.sleep(interval)
                 except GeneratorExit:
                     break
@@ -906,7 +906,6 @@ def market_price_stream():
                 failure_count += 1
                 backoff = min(60, backoff * 2) if failure_count > 1 else 1
                 try:
-                    import time
                     time.sleep(min(backoff, interval))
                 except GeneratorExit:
                     break
@@ -2522,7 +2521,6 @@ def autonomous_ingestion_loop():
     logger.info("🧠 Autonomous Ingestion worker started")
     
     # Wait for system to stabilize
-    import time
     time.sleep(30)
     
     while True:


### PR DESCRIPTION
🎯 **What:** Moved inline `import time` statements inside functions to the module level at the top of the file in `backend/main.py`.

💡 **Why:** This improves maintainability and readability by following standard Python practices for organizing imports. It ensures that dependencies are clearly visible at the top of the file and prevents redundant imports during function execution.

✅ **Verification:**
1. Ran `python3 -m py_compile backend/main.py` to ensure valid syntax.
2. Created a mock execution environment using `sys.modules` patching and ran the streaming functionality tests (`test_market_stream.py`, `test_streaming.py`, `test_all.py`) via `pytest` to confirm that the changes did not break the `time.sleep` behavior within the application. All tests passed.

✨ **Result:** The codebase is cleaner and adheres closer to PEP-8 standards regarding imports.

---
*PR created automatically by Jules for task [11314119607639243283](https://jules.google.com/task/11314119607639243283) started by @TechAD101*