### PR TITLE
⚡ perf: Add TTL cache to market data fetch

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -255,6 +255,38 @@ def _get_git_version() -> Dict[str, str]:
 
 
 
+import time
+from functools import wraps
+
+def ttl_cache(maxsize=128, ttl=60):
+    """
+    A simple TTL (Time To Live) cache implementation using a dictionary.
+    """
+    def wrapper(func):
+        cache = {}
+
+        @wraps(func)
+        def inner(*args, **kwargs):
+            key = str(args) + str(kwargs)
+            now = time.time()
+
+            if key in cache:
+                result, timestamp = cache[key]
+                if now - timestamp < ttl:
+                    return result
+
+            result = func(*args, **kwargs)
+
+            if len(cache) >= maxsize:
+                oldest_key = min(cache.keys(), key=lambda k: cache[k][1])
+                del cache[oldest_key]
+
+            cache[key] = (result, now)
+            return result
+        return inner
+    return wrapper
+
+@ttl_cache(maxsize=100, ttl=60)
 def unified_get_market_price(symbol: str) -> Dict[str, Any]:
     """Get current market price for a symbol using configured provider (FMP-first).
 

--- a/backend/tests/test_all.py
+++ b/backend/tests/test_all.py
@@ -1,0 +1,53 @@
+import sys
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.append(os.path.abspath('backend'))
+
+# Mock required dependencies to allow import
+sys.modules['flask'] = MagicMock()
+sys.modules['flask_cors'] = MagicMock()
+sys.modules['flask_sqlalchemy'] = MagicMock()
+sys.modules['psycopg2'] = MagicMock()
+sys.modules['redis'] = MagicMock()
+sys.modules['sqlalchemy'] = MagicMock()
+sys.modules['sqlalchemy.orm'] = MagicMock()
+sys.modules['sqlalchemy.ext.declarative'] = MagicMock()
+sys.modules['chromadb'] = MagicMock()
+sys.modules['langchain'] = MagicMock()
+sys.modules['openai'] = MagicMock()
+sys.modules['tiktoken'] = MagicMock()
+sys.modules['numpy'] = MagicMock()
+sys.modules['pandas'] = MagicMock()
+sys.modules['scipy'] = MagicMock()
+sys.modules['sklearn'] = MagicMock()
+sys.modules['yfinance'] = MagicMock()
+sys.modules['requests'] = MagicMock()
+sys.modules['google'] = MagicMock()
+
+import main
+
+class TestCache(unittest.TestCase):
+    def test_cache_functionality(self):
+        # Using a mock massive fetch quote method to track calls
+        mock_fetch = MagicMock(return_value={"price": 100})
+
+        with patch.object(main, 'MARKET_SERVICE_READY', False), patch('os.getenv') as mock_getenv:
+            # force Massive
+            def getenv_side_effect(key, default=None):
+                if key == 'MASSIVE_API_KEY': return 'fake_key'
+                return default
+            mock_getenv.side_effect = getenv_side_effect
+
+            with patch('services.market_data_service_massive.MassiveMarketDataService.fetch_quote', mock_fetch):
+                # Call multiple times
+                main.unified_get_market_price('AAPL')
+                main.unified_get_market_price('AAPL')
+                main.unified_get_market_price('AAPL')
+
+                # Should only be called once because of cache
+                mock_fetch.assert_called_once_with('AAPL')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
💡 **What:**
Implemented a custom `@ttl_cache` decorator utilizing `time.time()` and applied it to the `unified_get_market_price` function in `backend/main.py` with a 60-second time-to-live and a max size of 100 entries.

🎯 **Why:**
`unified_get_market_price` fetches stock prices via external API calls (FMP or Massive/Polygon) on every invocation without any local caching. This causes significant performance bottlenecks, network overhead, and rapidly consumes API limits during bursts of repetitive requests.

📊 **Measured Improvement:**
A focused benchmark was created to fetch the 'AAPL' price 5 consecutive times, with an induced 0.5s network latency:
- **Baseline:** 2.50 seconds (5 distinct API calls).
- **With Optimization:** ~0.50 seconds (1 API call + 4 cached responses).
- **Change:** 5x speedup for this access pattern, massively reducing external dependencies.

---
*PR created automatically by Jules for task [13734429591326092068](https://jules.google.com/task/13734429591326092068) started by @TechAD101*