### PR TITLE
🧪 Add tests for get_social_sentiment in market_sentiment_service

### DIFF
--- a/tests/test_market_sentiment_service.py
+++ b/tests/test_market_sentiment_service.py
@@ -3,70 +3,96 @@ import os
 import pytest
 from unittest.mock import patch, MagicMock
 
-# Create mocked versions
-mock_np = MagicMock()
-mock_requests = MagicMock()
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
 
-# Instead of blindly overriding sys.modules directly, we do it conditionally
-# This ensures that if the system HAS numpy installed (like in CI), it will import natively
-# But locally where it might be missing, it prevents ModuleNotFoundError
+# Check if numpy is available. In CI it is, locally it isn't.
+# If it's not available, we MUST mock it in sys.modules BEFORE importing the service.
+_mocked_numpy = False
 try:
-    import numpy as np
+    import numpy
 except ImportError:
     import unittest.mock
+    mock_np = MagicMock()
     sys.modules['numpy'] = mock_np
+    _mocked_numpy = True
 
 try:
     import requests
 except ImportError:
     import unittest.mock
-    sys.modules['requests'] = mock_requests
+    sys.modules['requests'] = MagicMock()
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
 from services.market_sentiment_service import MarketSentimentService
 
 @pytest.fixture
 def service():
     return MarketSentimentService()
 
-@patch('services.market_sentiment_service.np.random.uniform')
-@patch('services.market_sentiment_service.np.random.randint')
-def test_get_social_sentiment_strongly_bullish(mock_randint, mock_uniform, service):
-    mock_uniform.side_effect = lambda low, high: high
-    mock_randint.return_value = 1000
+def test_get_social_sentiment_strongly_bullish(service):
+    # Depending on whether numpy was mocked via sys.modules or exists natively,
+    # we patch differently to ensure it works in both environments.
+    if _mocked_numpy:
+        with patch.dict(sys.modules, {'numpy': sys.modules['numpy']}):
+            sys.modules['numpy'].random.uniform.side_effect = lambda low, high: high
+            sys.modules['numpy'].random.randint.return_value = 1000
+            result = service.get_social_sentiment('AAPL')
+    else:
+        with patch('services.market_sentiment_service.np.random.uniform') as mock_uniform, \
+             patch('services.market_sentiment_service.np.random.randint') as mock_randint:
+            mock_uniform.side_effect = lambda low, high: high
+            mock_randint.return_value = 1000
+            result = service.get_social_sentiment('AAPL')
 
-    result = service.get_social_sentiment('AAPL')
     assert result['signal'] == 'STRONGLY_BULLISH'
     assert result['overall_sentiment'] > 0.65
     assert result['symbol'] == 'AAPL'
     assert 'timestamp' in result
     assert 'sources' in result
 
-@patch('services.market_sentiment_service.np.random.uniform')
-@patch('services.market_sentiment_service.np.random.randint')
-def test_get_social_sentiment_strongly_bearish(mock_randint, mock_uniform, service):
-    mock_uniform.side_effect = lambda low, high: low
-    mock_randint.return_value = 1000
+def test_get_social_sentiment_strongly_bearish(service):
+    if _mocked_numpy:
+        with patch.dict(sys.modules, {'numpy': sys.modules['numpy']}):
+            sys.modules['numpy'].random.uniform.side_effect = lambda low, high: low
+            sys.modules['numpy'].random.randint.return_value = 1000
+            result = service.get_social_sentiment('AAPL')
+    else:
+        with patch('services.market_sentiment_service.np.random.uniform') as mock_uniform, \
+             patch('services.market_sentiment_service.np.random.randint') as mock_randint:
+            mock_uniform.side_effect = lambda low, high: low
+            mock_randint.return_value = 1000
+            result = service.get_social_sentiment('AAPL')
 
-    result = service.get_social_sentiment('AAPL')
     assert result['signal'] == 'STRONGLY_BEARISH'
     assert result['overall_sentiment'] <= 0.35
 
-@patch('services.market_sentiment_service.np.random.uniform')
-@patch('services.market_sentiment_service.np.random.randint')
-def test_get_social_sentiment_neutral(mock_randint, mock_uniform, service):
-    mock_uniform.side_effect = lambda low, high: 0.0 if low < 0 else (low + high) / 2
-    mock_randint.return_value = 1000
+def test_get_social_sentiment_neutral(service):
+    if _mocked_numpy:
+        with patch.dict(sys.modules, {'numpy': sys.modules['numpy']}):
+            sys.modules['numpy'].random.uniform.side_effect = lambda low, high: 0.0 if low < 0 else (low + high) / 2
+            sys.modules['numpy'].random.randint.return_value = 1000
+            result = service.get_social_sentiment('AAPL')
+    else:
+        with patch('services.market_sentiment_service.np.random.uniform') as mock_uniform, \
+             patch('services.market_sentiment_service.np.random.randint') as mock_randint:
+            mock_uniform.side_effect = lambda low, high: 0.0 if low < 0 else (low + high) / 2
+            mock_randint.return_value = 1000
+            result = service.get_social_sentiment('AAPL')
 
-    result = service.get_social_sentiment('AAPL')
     assert result['signal'] == 'NEUTRAL'
     assert 0.45 < result['overall_sentiment'] <= 0.55
 
-@patch('services.market_sentiment_service.np.random.uniform')
-def test_get_social_sentiment_exception_fallback(mock_uniform, service):
-    mock_uniform.side_effect = Exception("API failure")
+def test_get_social_sentiment_exception_fallback(service):
+    if _mocked_numpy:
+        with patch.dict(sys.modules, {'numpy': sys.modules['numpy']}):
+            sys.modules['numpy'].random.uniform.side_effect = Exception("API failure")
+            result = service.get_social_sentiment('AAPL')
+            # Reset side effect
+            sys.modules['numpy'].random.uniform.side_effect = None
+    else:
+        with patch('services.market_sentiment_service.np.random.uniform') as mock_uniform:
+            mock_uniform.side_effect = Exception("API failure")
+            result = service.get_social_sentiment('AAPL')
 
-    result = service.get_social_sentiment('AAPL')
     assert result['signal'] == 'NEUTRAL'
     assert result['overall_sentiment'] == 0.5
     assert result['symbol'] == 'AAPL'

--- a/tests/test_market_sentiment_service.py
+++ b/tests/test_market_sentiment_service.py
@@ -5,94 +5,90 @@ from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
 
-# Check if numpy is available. In CI it is, locally it isn't.
-# If it's not available, we MUST mock it in sys.modules BEFORE importing the service.
-_mocked_numpy = False
-try:
-    import numpy
-except ImportError:
-    import unittest.mock
-    mock_np = MagicMock()
-    sys.modules['numpy'] = mock_np
-    _mocked_numpy = True
+# We cannot reliably guess when to conditionally mock using `try...except ImportError`
+# in an environment where numpy might exist but `services.market_sentiment_service.np` behaves strangely
+# when patched.
+#
+# A much safer and universal pattern for mocking missing dependencies in these
+# restricted environments that prevents both `ModuleNotFoundError` locally AND
+# `AssertionError` (MagicMock evaluation) remotely is to ALWAYS patch using `sys.modules`.
+#
+# However, we must provide a minimal viable mock of `numpy.random` that actually works
+# if the backend code attempts to invoke it.
 
-try:
-    import requests
-except ImportError:
-    import unittest.mock
-    sys.modules['requests'] = MagicMock()
+import unittest.mock
 
-from services.market_sentiment_service import MarketSentimentService
+mock_np = MagicMock()
+# Provide explicit, usable MagicMocks that can be patched over
+mock_np.random = MagicMock()
+mock_np.random.uniform = MagicMock()
+mock_np.random.randint = MagicMock()
+
+mocks = {
+    'numpy': mock_np,
+    'requests': MagicMock()
+}
+
+# Apply the sys.modules patch globally for this test file context
+with unittest.mock.patch.dict(sys.modules, mocks):
+    from services.market_sentiment_service import MarketSentimentService
 
 @pytest.fixture
 def service():
-    return MarketSentimentService()
+    # Because MarketSentimentService might be instantiating things at runtime that need numpy,
+    # we ensure the fixture also runs inside the patch context.
+    with unittest.mock.patch.dict(sys.modules, mocks):
+        return MarketSentimentService()
 
 def test_get_social_sentiment_strongly_bullish(service):
-    # Depending on whether numpy was mocked via sys.modules or exists natively,
-    # we patch differently to ensure it works in both environments.
-    if _mocked_numpy:
-        with patch.dict(sys.modules, {'numpy': sys.modules['numpy']}):
-            sys.modules['numpy'].random.uniform.side_effect = lambda low, high: high
-            sys.modules['numpy'].random.randint.return_value = 1000
-            result = service.get_social_sentiment('AAPL')
-    else:
-        with patch('services.market_sentiment_service.np.random.uniform') as mock_uniform, \
-             patch('services.market_sentiment_service.np.random.randint') as mock_randint:
-            mock_uniform.side_effect = lambda low, high: high
-            mock_randint.return_value = 1000
-            result = service.get_social_sentiment('AAPL')
+    with unittest.mock.patch.dict(sys.modules, mocks):
+        # Directly set the behavior of our mock_np object
+        mock_np.random.uniform.side_effect = lambda low, high: high
+        mock_np.random.randint.return_value = 1000
 
-    assert result['signal'] == 'STRONGLY_BULLISH'
-    assert result['overall_sentiment'] > 0.65
-    assert result['symbol'] == 'AAPL'
-    assert 'timestamp' in result
-    assert 'sources' in result
+        result = service.get_social_sentiment('AAPL')
+
+        assert result['signal'] == 'STRONGLY_BULLISH'
+        assert result['overall_sentiment'] > 0.65
+        assert result['symbol'] == 'AAPL'
+        assert 'timestamp' in result
+        assert 'sources' in result
+
+        # Reset side effect for isolation
+        mock_np.random.uniform.side_effect = None
 
 def test_get_social_sentiment_strongly_bearish(service):
-    if _mocked_numpy:
-        with patch.dict(sys.modules, {'numpy': sys.modules['numpy']}):
-            sys.modules['numpy'].random.uniform.side_effect = lambda low, high: low
-            sys.modules['numpy'].random.randint.return_value = 1000
-            result = service.get_social_sentiment('AAPL')
-    else:
-        with patch('services.market_sentiment_service.np.random.uniform') as mock_uniform, \
-             patch('services.market_sentiment_service.np.random.randint') as mock_randint:
-            mock_uniform.side_effect = lambda low, high: low
-            mock_randint.return_value = 1000
-            result = service.get_social_sentiment('AAPL')
+    with unittest.mock.patch.dict(sys.modules, mocks):
+        mock_np.random.uniform.side_effect = lambda low, high: low
+        mock_np.random.randint.return_value = 1000
 
-    assert result['signal'] == 'STRONGLY_BEARISH'
-    assert result['overall_sentiment'] <= 0.35
+        result = service.get_social_sentiment('AAPL')
+
+        assert result['signal'] == 'STRONGLY_BEARISH'
+        assert result['overall_sentiment'] <= 0.35
+
+        mock_np.random.uniform.side_effect = None
 
 def test_get_social_sentiment_neutral(service):
-    if _mocked_numpy:
-        with patch.dict(sys.modules, {'numpy': sys.modules['numpy']}):
-            sys.modules['numpy'].random.uniform.side_effect = lambda low, high: 0.0 if low < 0 else (low + high) / 2
-            sys.modules['numpy'].random.randint.return_value = 1000
-            result = service.get_social_sentiment('AAPL')
-    else:
-        with patch('services.market_sentiment_service.np.random.uniform') as mock_uniform, \
-             patch('services.market_sentiment_service.np.random.randint') as mock_randint:
-            mock_uniform.side_effect = lambda low, high: 0.0 if low < 0 else (low + high) / 2
-            mock_randint.return_value = 1000
-            result = service.get_social_sentiment('AAPL')
+    with unittest.mock.patch.dict(sys.modules, mocks):
+        mock_np.random.uniform.side_effect = lambda low, high: 0.0 if low < 0 else (low + high) / 2
+        mock_np.random.randint.return_value = 1000
 
-    assert result['signal'] == 'NEUTRAL'
-    assert 0.45 < result['overall_sentiment'] <= 0.55
+        result = service.get_social_sentiment('AAPL')
+
+        assert result['signal'] == 'NEUTRAL'
+        assert 0.45 < result['overall_sentiment'] <= 0.55
+
+        mock_np.random.uniform.side_effect = None
 
 def test_get_social_sentiment_exception_fallback(service):
-    if _mocked_numpy:
-        with patch.dict(sys.modules, {'numpy': sys.modules['numpy']}):
-            sys.modules['numpy'].random.uniform.side_effect = Exception("API failure")
-            result = service.get_social_sentiment('AAPL')
-            # Reset side effect
-            sys.modules['numpy'].random.uniform.side_effect = None
-    else:
-        with patch('services.market_sentiment_service.np.random.uniform') as mock_uniform:
-            mock_uniform.side_effect = Exception("API failure")
-            result = service.get_social_sentiment('AAPL')
+    with unittest.mock.patch.dict(sys.modules, mocks):
+        mock_np.random.uniform.side_effect = Exception("API failure")
 
-    assert result['signal'] == 'NEUTRAL'
-    assert result['overall_sentiment'] == 0.5
-    assert result['symbol'] == 'AAPL'
+        result = service.get_social_sentiment('AAPL')
+
+        assert result['signal'] == 'NEUTRAL'
+        assert result['overall_sentiment'] == 0.5
+        assert result['symbol'] == 'AAPL'
+
+        mock_np.random.uniform.side_effect = None

--- a/tests/test_market_sentiment_service.py
+++ b/tests/test_market_sentiment_service.py
@@ -3,68 +3,70 @@ import os
 import pytest
 from unittest.mock import patch, MagicMock
 
-# Mock dependencies to avoid ModuleNotFoundError in restricted environments
-import unittest.mock
-
+# Create mocked versions
 mock_np = MagicMock()
-mock_np.random.uniform.return_value = 0.5
-mock_np.random.randint.return_value = 1000
-
 mock_requests = MagicMock()
 
-mocks = {
-    'numpy': mock_np,
-    'requests': mock_requests
-}
+# Instead of blindly overriding sys.modules directly, we do it conditionally
+# This ensures that if the system HAS numpy installed (like in CI), it will import natively
+# But locally where it might be missing, it prevents ModuleNotFoundError
+try:
+    import numpy as np
+except ImportError:
+    import unittest.mock
+    sys.modules['numpy'] = mock_np
 
-with unittest.mock.patch.dict(sys.modules, mocks):
-    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
-    from services.market_sentiment_service import MarketSentimentService
+try:
+    import requests
+except ImportError:
+    import unittest.mock
+    sys.modules['requests'] = mock_requests
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+from services.market_sentiment_service import MarketSentimentService
 
 @pytest.fixture
 def service():
-    with unittest.mock.patch.dict(sys.modules, mocks):
-        return MarketSentimentService()
+    return MarketSentimentService()
 
-def test_get_social_sentiment_strongly_bullish(service):
-    with patch.dict(sys.modules, mocks):
-        # In this context, mock_np.random.uniform returns 0.5 which corresponds to STRONGLY_BULLISH
-        mock_np.random.uniform.side_effect = lambda low, high: high
-        mock_np.random.randint.return_value = 1000
+@patch('services.market_sentiment_service.np.random.uniform')
+@patch('services.market_sentiment_service.np.random.randint')
+def test_get_social_sentiment_strongly_bullish(mock_randint, mock_uniform, service):
+    mock_uniform.side_effect = lambda low, high: high
+    mock_randint.return_value = 1000
 
-        result = service.get_social_sentiment('AAPL')
-        assert result['signal'] == 'STRONGLY_BULLISH'
-        assert result['overall_sentiment'] > 0.65
-        assert result['symbol'] == 'AAPL'
-        assert 'timestamp' in result
-        assert 'sources' in result
+    result = service.get_social_sentiment('AAPL')
+    assert result['signal'] == 'STRONGLY_BULLISH'
+    assert result['overall_sentiment'] > 0.65
+    assert result['symbol'] == 'AAPL'
+    assert 'timestamp' in result
+    assert 'sources' in result
 
-def test_get_social_sentiment_strongly_bearish(service):
-    with patch.dict(sys.modules, mocks):
-        mock_np.random.uniform.side_effect = lambda low, high: low
-        mock_np.random.randint.return_value = 1000
+@patch('services.market_sentiment_service.np.random.uniform')
+@patch('services.market_sentiment_service.np.random.randint')
+def test_get_social_sentiment_strongly_bearish(mock_randint, mock_uniform, service):
+    mock_uniform.side_effect = lambda low, high: low
+    mock_randint.return_value = 1000
 
-        result = service.get_social_sentiment('AAPL')
-        assert result['signal'] == 'STRONGLY_BEARISH'
-        assert result['overall_sentiment'] <= 0.35
+    result = service.get_social_sentiment('AAPL')
+    assert result['signal'] == 'STRONGLY_BEARISH'
+    assert result['overall_sentiment'] <= 0.35
 
-def test_get_social_sentiment_neutral(service):
-    with patch.dict(sys.modules, mocks):
-        mock_np.random.uniform.side_effect = lambda low, high: 0.0 if low < 0 else (low + high) / 2
-        mock_np.random.randint.return_value = 1000
+@patch('services.market_sentiment_service.np.random.uniform')
+@patch('services.market_sentiment_service.np.random.randint')
+def test_get_social_sentiment_neutral(mock_randint, mock_uniform, service):
+    mock_uniform.side_effect = lambda low, high: 0.0 if low < 0 else (low + high) / 2
+    mock_randint.return_value = 1000
 
-        result = service.get_social_sentiment('AAPL')
-        assert result['signal'] == 'NEUTRAL'
-        assert 0.45 < result['overall_sentiment'] <= 0.55
+    result = service.get_social_sentiment('AAPL')
+    assert result['signal'] == 'NEUTRAL'
+    assert 0.45 < result['overall_sentiment'] <= 0.55
 
-def test_get_social_sentiment_exception_fallback(service):
-    with patch.dict(sys.modules, mocks):
-        mock_np.random.uniform.side_effect = Exception("API failure")
+@patch('services.market_sentiment_service.np.random.uniform')
+def test_get_social_sentiment_exception_fallback(mock_uniform, service):
+    mock_uniform.side_effect = Exception("API failure")
 
-        result = service.get_social_sentiment('AAPL')
-        assert result['signal'] == 'NEUTRAL'
-        assert result['overall_sentiment'] == 0.5
-        assert result['symbol'] == 'AAPL'
-
-        # Reset side effect for subsequent tests
-        mock_np.random.uniform.side_effect = None
+    result = service.get_social_sentiment('AAPL')
+    assert result['signal'] == 'NEUTRAL'
+    assert result['overall_sentiment'] == 0.5
+    assert result['symbol'] == 'AAPL'

--- a/tests/test_market_sentiment_service.py
+++ b/tests/test_market_sentiment_service.py
@@ -1,0 +1,70 @@
+import sys
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Mock dependencies to avoid ModuleNotFoundError in restricted environments
+import unittest.mock
+
+mock_np = MagicMock()
+mock_np.random.uniform.return_value = 0.5
+mock_np.random.randint.return_value = 1000
+
+mock_requests = MagicMock()
+
+mocks = {
+    'numpy': mock_np,
+    'requests': mock_requests
+}
+
+with unittest.mock.patch.dict(sys.modules, mocks):
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
+    from services.market_sentiment_service import MarketSentimentService
+
+@pytest.fixture
+def service():
+    with unittest.mock.patch.dict(sys.modules, mocks):
+        return MarketSentimentService()
+
+def test_get_social_sentiment_strongly_bullish(service):
+    with patch.dict(sys.modules, mocks):
+        # In this context, mock_np.random.uniform returns 0.5 which corresponds to STRONGLY_BULLISH
+        mock_np.random.uniform.side_effect = lambda low, high: high
+        mock_np.random.randint.return_value = 1000
+
+        result = service.get_social_sentiment('AAPL')
+        assert result['signal'] == 'STRONGLY_BULLISH'
+        assert result['overall_sentiment'] > 0.65
+        assert result['symbol'] == 'AAPL'
+        assert 'timestamp' in result
+        assert 'sources' in result
+
+def test_get_social_sentiment_strongly_bearish(service):
+    with patch.dict(sys.modules, mocks):
+        mock_np.random.uniform.side_effect = lambda low, high: low
+        mock_np.random.randint.return_value = 1000
+
+        result = service.get_social_sentiment('AAPL')
+        assert result['signal'] == 'STRONGLY_BEARISH'
+        assert result['overall_sentiment'] <= 0.35
+
+def test_get_social_sentiment_neutral(service):
+    with patch.dict(sys.modules, mocks):
+        mock_np.random.uniform.side_effect = lambda low, high: 0.0 if low < 0 else (low + high) / 2
+        mock_np.random.randint.return_value = 1000
+
+        result = service.get_social_sentiment('AAPL')
+        assert result['signal'] == 'NEUTRAL'
+        assert 0.45 < result['overall_sentiment'] <= 0.55
+
+def test_get_social_sentiment_exception_fallback(service):
+    with patch.dict(sys.modules, mocks):
+        mock_np.random.uniform.side_effect = Exception("API failure")
+
+        result = service.get_social_sentiment('AAPL')
+        assert result['signal'] == 'NEUTRAL'
+        assert result['overall_sentiment'] == 0.5
+        assert result['symbol'] == 'AAPL'
+
+        # Reset side effect for subsequent tests
+        mock_np.random.uniform.side_effect = None


### PR DESCRIPTION
🎯 **What:** The `get_social_sentiment` method in `MarketSentimentService` was untested. It contains complex weighted average calculation logic that relies on random values to simulate external API responses.

📊 **Coverage:** 
Created `tests/test_market_sentiment_service.py` to cover:
- STRONGLY_BULLISH scenario (mocked high numpy values)
- STRONGLY_BEARISH scenario (mocked low numpy values)
- NEUTRAL scenario (mocked zero/neutral numpy values)
- Exception handling (simulating an external API failure to ensure the `_get_neutral_social_sentiment` fallback is triggered)

✨ **Result:** 
Significant improvement in test coverage for the sentiment service. We can now confidently refactor the mocked API calls to actual service endpoints in the future knowing our threshold logic is verified. Tested for determinism and lack of flakiness by tightly scoping our mocks and ensuring proper `mock_np.random.uniform` and `mock_np.random.randint` returns per-test.

---
*PR created automatically by Jules for task [6619439687269632424](https://jules.google.com/task/6619439687269632424) started by @TechAD101*