### PR TITLE
🧹 [Code Health] Enforce abstract hook _adjust_weight_for_context

### DIFF
--- a/backend/ai_agents/base_agent.py
+++ b/backend/ai_agents/base_agent.py
@@ -47,6 +47,10 @@ class BaseAgent(PersonaAgent):
             weight=self.voting_weight
         )
     
+    def _adjust_weight_for_context(self, context: Dict[str, Any], base_weight: float) -> float:
+        """Placeholder weight adjustment"""
+        return base_weight
+
     def to_dict(self) -> Dict[str, Any]:
         """Serialize agent to dictionary"""
         return self.get_performance_summary()

--- a/backend/ai_agents/base_persona.py
+++ b/backend/ai_agents/base_persona.py
@@ -177,12 +177,13 @@ class PersonaAgent(ABC):
         
         return weight
     
+    @abstractmethod
     def _adjust_weight_for_context(self, context: Dict[str, Any], base_weight: float) -> float:
         """
         Hook for subclasses to adjust weight based on market context
         Override in subclasses for persona-specific logic
         """
-        return base_weight
+        pass
     
     def record_vote(self, vote: PersonaVote):
         """Record vote in history"""

--- a/backend/ai_agents/personas/degen_auditor.py
+++ b/backend/ai_agents/personas/degen_auditor.py
@@ -41,3 +41,7 @@ class DegenAuditorAgent(PersonaAgent):
             reasoning="Degen Auditor flags excessive retail froth. Capital preservation activated.",
             weight=self.voting_weight
         )
+
+    def _adjust_weight_for_context(self, context: Dict[str, Any], base_weight: float) -> float:
+        """Placeholder weight adjustment"""
+        return base_weight

--- a/backend/ai_agents/personas/macro_monk.py
+++ b/backend/ai_agents/personas/macro_monk.py
@@ -38,3 +38,7 @@ class MacroMonkAgent(PersonaAgent):
             reasoning="Macro alignment confirmed.",
             weight=self.voting_weight
         )
+
+    def _adjust_weight_for_context(self, context: Dict[str, Any], base_weight: float) -> float:
+        """Placeholder weight adjustment"""
+        return base_weight

--- a/backend/ai_agents/personas/quant.py
+++ b/backend/ai_agents/personas/quant.py
@@ -39,3 +39,7 @@ class QuantAgent(PersonaAgent):
             reasoning="Algorithm confirms optimal Z-score thresholds for entry.",
             weight=self.voting_weight
         )
+
+    def _adjust_weight_for_context(self, context: Dict[str, Any], base_weight: float) -> float:
+        """Placeholder weight adjustment"""
+        return base_weight

--- a/backend/ai_agents/personas/the_ghost.py
+++ b/backend/ai_agents/personas/the_ghost.py
@@ -38,3 +38,7 @@ class TheGhostAgent(PersonaAgent):
             reasoning="The Ghost senses uncertainty in current liquidity zones.",
             weight=self.voting_weight
         )
+
+    def _adjust_weight_for_context(self, context: Dict[str, Any], base_weight: float) -> float:
+        """Placeholder weight adjustment"""
+        return base_weight


### PR DESCRIPTION
🎯 **What:** Enforced the `_adjust_weight_for_context` method in `PersonaAgent` to be an abstract method instead of a default method returning `base_weight`.
💡 **Why:** Explicitly making it an abstract method improves maintainability and readability, enforcing clearer inheritance patterns for subclassing personas.
✅ **Verification:** A custom test suite was run (`python3 test_personas.py`) ensuring no runtime instantiation errors and identical output behavior.
✨ **Result:** A more explicit, typed code architecture for PersonaAgent definitions.

---
*PR created automatically by Jules for task [10360118612943578201](https://jules.google.com/task/10360118612943578201) started by @TechAD101*